### PR TITLE
Fix option element rendering

### DIFF
--- a/scripts/convictions/ConvictionProvider.js
+++ b/scripts/convictions/ConvictionProvider.js
@@ -10,7 +10,6 @@ export const getConvictions = () => {
    return fetch("https://criminals.glassdale.us/crimes")
     .then(response => response.json())
     .then(parsedConvictions => {
-        // console.table(parsedConvictions)
         convictions = parsedConvictions
     })
 }

--- a/scripts/convictions/ConvictionSelect.js
+++ b/scripts/convictions/ConvictionSelect.js
@@ -31,13 +31,14 @@ export const ConvictionSelect = () => {
 }
 
 const _render = convictionsCollection => {
+
     contentTarget.innerHTML = `
         <select class="dropdown" id="crimeSelect">
             <option value="0">Please select a crime...</option>
             ${
-                convictionsCollection.map((conviction) =>{
-                    return `<option>${conviction.name}</option>`
-                }).join("")
+                convictionsCollection.map((conviction) =>
+                    `<option value="${conviction.id}">${conviction.name}</option>`
+                ).join("")
             }
         </select>
     `

--- a/scripts/convictions/ConvictionSelect.js
+++ b/scripts/convictions/ConvictionSelect.js
@@ -36,9 +36,8 @@ const _render = convictionsCollection => {
             <option value="0">Please select a crime...</option>
             ${
                 convictionsCollection.map((conviction) =>{
-                    const crime = conviction.name
-                    return `<option>${crime}</option>`
-                })
+                    return `<option>${conviction.name}</option>`
+                }).join("")
             }
         </select>
     `

--- a/scripts/criminals/CriminalList.js
+++ b/scripts/criminals/CriminalList.js
@@ -1,5 +1,6 @@
 import { getCriminals, useCriminals } from "./CriminalDataProvider.js"
 import { Criminal } from "./Criminal.js"
+import { useConvictions } from "../convictions/ConvictionProvider.js"
 
 let contentElement = document.querySelector(".criminalsContainer")
 // export const CriminalList = () => {
@@ -33,19 +34,31 @@ eventHub.addEventListener("crimeChosen", event => {
         commited the crime.
     */
 
-   if(event.detail.crimeThatWasChosen !== "0") {
 
-    const crime = event.detail.crimeThatWasChosen
-    const appStateCriminals = useCriminals()
-    const matchingCriminals = appStateCriminals.filter((criminalObj) => criminalObj.conviction === crime)
-    
+   if(event.detail.crimeThatWasChosen !== "0") {
+       // string representation of number
+    /* 
+      We have the the id of the conviction that the user selected
+      from the drop down (event.target.crimeThatWasChosen). But
+        each criminal object has the name of the crime they were
+        convicted for. So we need to get the name of the conviction
+        associated with the unique identifier. To get the name, we 
+        get the conviction object which has the property for name. 
+    */
+       const convictionNum = event.detail.crimeThatWasChosen
+
+       const convictionArray = useConvictions()
+
+       // Get conviction object by id
+        const convictionObjFromId = convictionArray.find((convictionObj) => convictionObj.id === parseInt(convictionNum))
+
+        const appStateCriminals = useCriminals()
+        const matchingCriminals = appStateCriminals.filter((criminalObj) => criminalObj.conviction === convictionObjFromId.name)    
     render(matchingCriminals)
     } else {
-        console.log("in else)")
+        // show default criminal list
         CriminalList()
     }
-        
-
 })
 
 const render = criminalCollection => {

--- a/scripts/criminals/CriminalList.js
+++ b/scripts/criminals/CriminalList.js
@@ -53,7 +53,7 @@ const render = criminalCollection => {
     contentElement.innerHTML = `
         <h2>Glassdale's Criminals</h2>
         <section class="criminalList">
-            ${criminalCollection.map((criminalObj)=> Criminal(criminalObj))}
+            ${criminalCollection.map((criminalObj)=> Criminal(criminalObj)).join("")}
         </section>   
     `
 }


### PR DESCRIPTION
# Description
Render criminals to dom by default view or by crime in the drop down.
No errors should populate the console.
Criminals are now filtered by conviction.name found in selector, then populate the dom.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Testing Instructions

`git fetch --all`
`git checkout fix-option-element-rendering`
`serve`
